### PR TITLE
Configuration tweaks and fixed up checkstyle errors

### DIFF
--- a/bundles/org.openhab.binding.playstation/src/main/java/org/openhab/binding/playstation/internal/PS3Handler.java
+++ b/bundles/org.openhab.binding.playstation/src/main/java/org/openhab/binding/playstation/internal/PS3Handler.java
@@ -60,9 +60,7 @@ public class PS3Handler extends BaseThingHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        if (command instanceof RefreshType) {
-            // Don't do anything, just wait for the timer.
-        } else {
+        if (!(command instanceof RefreshType)) {
             if (CHANNEL_POWER.equals(channelUID.getId()) && command instanceof OnOffType) {
                 if (command.equals(OnOffType.ON)) {
                     turnOnPS3();
@@ -123,7 +121,6 @@ public class PS3Handler extends BaseThingHandler {
     }
 
     private void turnOnPS3() {
-
         try {
             InetAddress bcAddress = InetAddress.getByName("255.255.255.255");
 
@@ -149,7 +146,10 @@ public class PS3Handler extends BaseThingHandler {
 
     private void wakeMethod(DatagramPacket srchPacket, DatagramPacket receivePacket, DatagramPacket wakePacket,
             int triesLeft) {
-        try (DatagramSocket searchSocket = new DatagramSocket(); DatagramSocket wakeSocket = new DatagramSocket();) {
+        try (
+            DatagramSocket searchSocket = new DatagramSocket(); 
+            DatagramSocket wakeSocket = new DatagramSocket();
+        ) {
             wakeSocket.setBroadcast(true);
             searchSocket.setBroadcast(true);
             searchSocket.setSoTimeout(1000);

--- a/bundles/org.openhab.binding.playstation/src/main/java/org/openhab/binding/playstation/internal/PS4ArtworkHandler.java
+++ b/bundles/org.openhab.binding.playstation/src/main/java/org/openhab/binding/playstation/internal/PS4ArtworkHandler.java
@@ -36,8 +36,8 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class PS4ArtworkHandler {
 
-    private static final Logger logger = LoggerFactory.getLogger(PS4ArtworkHandler.class);
-    private static final File artworkCacheFolder;
+    private static final Logger LOGGER = LoggerFactory.getLogger(PS4ArtworkHandler.class);
+    private static final File ARTWORK_CACHE_FOLDER;
 
     /** Service pid */
     private static final String SERVICE_PID = "org.openhab.binding.playstation";
@@ -60,15 +60,15 @@ public class PS4ArtworkHandler {
         if (!homeFolder.exists()) {
             homeFolder.mkdirs();
         }
-        logger.debug("Using home folder: {}", homeFolder.getAbsolutePath());
+        LOGGER.debug("Using home folder: {}", homeFolder.getAbsolutePath());
 
         // create binding folder
         File cacheFolder = new File(homeFolder, SERVICE_PID);
         if (!cacheFolder.exists()) {
             cacheFolder.mkdirs();
         }
-        logger.debug("Using cache folder {}", cacheFolder.getAbsolutePath());
-        artworkCacheFolder = cacheFolder;
+        LOGGER.debug("Using cache folder {}", cacheFolder.getAbsolutePath());
+        ARTWORK_CACHE_FOLDER = cacheFolder;
     }
 
     /**
@@ -118,18 +118,18 @@ public class PS4ArtworkHandler {
             return artwork;
         }
         String artworkFilename = titleId + "_" + size.toString() + ".jpg";
-        File artworkFileInCache = new File(artworkCacheFolder, artworkFilename);
+        File artworkFileInCache = new File(ARTWORK_CACHE_FOLDER, artworkFilename);
         if (artworkFileInCache.exists() && !forceRefetch) {
-            logger.debug("Artwork file {} was found in cache.", artworkFileInCache.getName());
+            LOGGER.debug("Artwork file {} was found in cache.", artworkFileInCache.getName());
             int length = (int) artworkFileInCache.length();
             byte[] fileBuffer = new byte[length];
             try (FileInputStream fis = new FileInputStream(artworkFileInCache)) {
                 fis.read(fileBuffer, 0, length);
                 artwork = new RawType(fileBuffer, "image/jpeg");
             } catch (FileNotFoundException ex) {
-                logger.debug("Could not find {} in cache. ", artworkFileInCache, ex);
+                LOGGER.debug("Could not find {} in cache. ", artworkFileInCache, ex);
             } catch (IOException ex) {
-                logger.warn("Could not read {} from cache. ", artworkFileInCache, ex);
+                LOGGER.warn("Could not read {} from cache. ", artworkFileInCache, ex);
             }
             if (artwork != null) {
                 return artwork;
@@ -145,15 +145,15 @@ public class PS4ArtworkHandler {
         }
         if (artwork != null) {
             try (FileOutputStream fos = new FileOutputStream(artworkFileInCache)) {
-                logger.debug("Caching artwork file {}", artworkFileInCache.getName());
+                LOGGER.debug("Caching artwork file {}", artworkFileInCache.getName());
                 fos.write(artwork.getBytes(), 0, artwork.getBytes().length);
             } catch (FileNotFoundException ex) {
-                logger.info("Could not create {} in cache. ", artworkFileInCache, ex);
+                LOGGER.info("Could not create {} in cache. ", artworkFileInCache, ex);
             } catch (IOException ex) {
-                logger.warn("Could not write {} to cache. ", artworkFileInCache, ex);
+                LOGGER.warn("Could not write {} to cache. ", artworkFileInCache, ex);
             }
         } else {
-            logger.debug("Could not download artwork file from {}", request);
+            LOGGER.debug("Could not download artwork file from {}", request);
         }
         return artwork;
     }

--- a/bundles/org.openhab.binding.playstation/src/main/java/org/openhab/binding/playstation/internal/PS4Handler.java
+++ b/bundles/org.openhab.binding.playstation/src/main/java/org/openhab/binding/playstation/internal/PS4Handler.java
@@ -337,7 +337,6 @@ public class PS4Handler extends BaseThingHandler {
         return true;
     }
 
-    @NonNullByDefault
     private class SocketChannelHandler extends Thread {
         private SocketChannel socketChannel;
 

--- a/bundles/org.openhab.binding.playstation/src/main/java/org/openhab/binding/playstation/internal/PS4Handler.java
+++ b/bundles/org.openhab.binding.playstation/src/main/java/org/openhab/binding/playstation/internal/PS4Handler.java
@@ -337,6 +337,7 @@ public class PS4Handler extends BaseThingHandler {
         return true;
     }
 
+    @NonNullByDefault
     private class SocketChannelHandler extends Thread {
         private SocketChannel socketChannel;
 

--- a/bundles/org.openhab.binding.playstation/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.playstation/src/main/resources/ESH-INF/config/config.xml
@@ -18,12 +18,12 @@
 			<label>User credential</label>
 			<description>User credential to communicate with the PlayStation 4.</description>
 		</parameter>
-		<parameter name="passCode" type="text" max="4" pattern="[0-9]*">
+		<parameter name="passCode" type="text" min="4" max="4" pattern="[0-9]*">
 			<context>password</context>
 			<label>Pass code</label>
 			<description>Pass code to log in to PlayStation 4.</description>
 		</parameter>
-		<parameter name="pairingCode" type="text" max="8" pattern="[0-9]*">
+		<parameter name="pairingCode" type="text" min="8" max="8" pattern="[0-9]*">
 			<label>Pairing code</label>
 			<description>Code to pair OpenHAB device to PlayStation 4. Only needed during pairing.</description>
 		</parameter>

--- a/bundles/org.openhab.binding.playstation/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.playstation/src/main/resources/ESH-INF/config/config.xml
@@ -14,17 +14,18 @@
 	</config-description>
 
 	<config-description uri="thing-type:playstation:PS4">
-		<parameter name="userCredential" type="text" required="true">
+		<parameter name="userCredential" type="text" required="true" min="64" max="64" pattern="[0-9A-Fa-f]*">
 			<label>User credential</label>
-			<description>User credential to communicate with the PlayStation 4, 64 hex characters.</description>
+			<description>User credential to communicate with the PlayStation 4.</description>
 		</parameter>
-		<parameter name="passCode" type="text">
+		<parameter name="passCode" type="text" max="4" pattern="[0-9]*">
+			<context>password</context>
 			<label>Pass code</label>
-			<description>Pass code to log in to PlayStation 4, optional, 4 digits.</description>
+			<description>Pass code to log in to PlayStation 4.</description>
 		</parameter>
-		<parameter name="pairingCode" type="text">
+		<parameter name="pairingCode" type="text" max="8" pattern="[0-9]*">
 			<label>Pairing code</label>
-			<description>Code to pair OpenHAB device to PlayStation 4, only needed during pairing, 8 digits.</description>
+			<description>Code to pair OpenHAB device to PlayStation 4. Only needed during pairing.</description>
 		</parameter>
 		<parameter name="connectionTimeout" type="integer" min="0">
 			<label>Connection timeout</label>

--- a/bundles/org.openhab.binding.playstation/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.playstation/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -80,17 +80,6 @@
 		<label>Application ID</label>
 		<description>ID of the currently running application.</description>
 		<category>MediaControl</category>
-		<state>
-			<options>
-				<option value="CUSA00127">Netflix</option>
-				<option value="CUSA01116">Youtube</option>
-				<option value="CUSA00124">Viaplay</option>
-				<option value="CUSA02827">HBO</option>
-				<option value="CUSA01780">Spotify</option>
-				<option value="CUSA11993">Marvel's Spider-Man</option>
-				<option value="CUSA00342">Other game</option>
-			</options>
-		</state>
 	</channel-type>
 	<channel-type id="applicationImage-channel">
 		<item-type>Image</item-type>


### PR DESCRIPTION
* I've improved the configuration validation so that the Pass Code, Pairing code and User Id all require the correct characters and length. The Pass Code is also noted as a password field so it is masked in Paper UI.
* I've removed the *state options* that were in the Application ID channel because:
  * You are not able to enter in your own App Id in Paper UI when there are state options
  * The options are not relevant to most users
* Fixed up checkstyle errors. There is still the matter of
 `PS4ArtworkHandler.java: bad practice, Logger should be non-static field (SLF4J). Change this field (LOGGER) to non-static field.` however I did not change this as the class it is in a static class and I'm not fully versed in Java Static Classes. The same field was also renamed from `logger` to `LOGGER` as per the style rules for static field names.

*Let me apologize - I mistakenly pushed directly to your repository about 10 minutes ago instead of mine with the changes here. Once I realized my mistake, I corrected it quickly by removing my commit. Not sure how I was able to push directly to your repo though!*